### PR TITLE
Implement --no-prompt flag

### DIFF
--- a/mpbridge/bridge.py
+++ b/mpbridge/bridge.py
@@ -52,7 +52,7 @@ def sync(port: str, path: str, clean: bool):
     pyb.exit_raw_repl_verbose()
 
 
-def start_dev_mode(port: str, path: str, auto_reset: str):
+def start_dev_mode(port: str, path: str, auto_reset: str, no_prompt: bool):
     path = utils.replace_backslashes(path)
     port = utils.port_abbreviation(port)
     print(Fore.YELLOW, f"- Syncing files on {port} with {path}")
@@ -61,14 +61,14 @@ def start_dev_mode(port: str, path: str, auto_reset: str):
     while True:
         pyb = SweetPyboard(device=port)
         pyb.enter_raw_repl_verbose()
-        pyb.sync_with_dir(dir_path=path)
-        old_ls = utils.recursive_list_dir(path)
-        print(Fore.LIGHTWHITE_EX +
-              " ? Press [Enter] to Sync & Enter REPL\n" +
-              "   Press [Ctrl + C] to exit ", end="")
-        utils.reset_term_color()
-        input()
-        push_deletes(pyb, path, old_ls=old_ls)
+        if not no_prompt:
+            pyb.sync_with_dir(dir_path=path)
+            print(Fore.LIGHTWHITE_EX +
+                  " ? Press [Enter] to Sync & Enter REPL\n" +
+                  "   Press [Ctrl + C] to exit ", end="")
+            utils.reset_term_color()
+            input()
+        pyb.delete_absent_items(dir_path=path)
         pyb.sync_with_dir(dir_path=path)
         if auto_reset is None:
             pyb.exit_raw_repl()

--- a/mpbridge/shell.py
+++ b/mpbridge/shell.py
@@ -51,9 +51,10 @@ def sync(port, dir_path, clean):
 @click.argument('port')
 @click.argument('dir_path', type=click.Path(
     exists=True, file_okay=False, dir_okay=True, resolve_path=True))
-@click.option('--auto-reset',
+@click.option('--auto-reset', help="Enables auto reset before entering REPL",
               type=click.Choice(['soft', 'hard'], case_sensitive=False))
-def dev(port, dir_path, auto_reset):
+@click.option('--no-prompt', is_flag=True, help="Disables prompt for entering REPL")
+def dev(port, dir_path, auto_reset, no_prompt: bool):
     """Start development mode on <PORT> in specified directory <DIR_PATH>
 
     <PORT> can be full path or :
@@ -64,7 +65,7 @@ def dev(port, dir_path, auto_reset):
 
             c[n]  connect to serial port "COM[n]"
     """
-    bridge.start_dev_mode(port, dir_path, auto_reset=auto_reset)
+    bridge.start_dev_mode(port, dir_path, auto_reset=auto_reset, no_prompt=no_prompt)
 
 
 @main.command("clear", short_help='Delete all files from MicroPython device')


### PR DESCRIPTION
This option disables prompt for entering REPL and reduces syncs to one time on each cycle.